### PR TITLE
Fixes bug in emailsvr docker file

### DIFF
--- a/applications/emailsvr/UbuntuServerX86-64/Dockerfile
+++ b/applications/emailsvr/UbuntuServerX86-64/Dockerfile
@@ -40,6 +40,7 @@ RUN chmod +x /root/postfix_install.sh
 RUN /root/postfix_install.sh
 RUN apt-get install postfix -y
 RUN apt-get install spamassassin spamc -y
+RUN apt-get install spamass-milter -y
 
 # configure postfix
 COPY postfix/etc_postfix_main.cf /etc/postfix/main.cf


### PR DESCRIPTION
From the instructions, we are using spamass-milter with postfix but we are not installing it while creating our docker image. Because of this issue, SPAM filtering is not working. Patch should fix the issue.