### PR TITLE
Fixes the issue with postfix-pcre

### DIFF
--- a/applications/emailsvr/UbuntuServerX86-64/Dockerfile
+++ b/applications/emailsvr/UbuntuServerX86-64/Dockerfile
@@ -41,6 +41,7 @@ RUN /root/postfix_install.sh
 RUN apt-get install postfix -y
 RUN apt-get install spamassassin spamc -y
 RUN apt-get install spamass-milter -y
+RUN apt-get install postfix-pcre -y
 
 # configure postfix
 COPY postfix/etc_postfix_main.cf /etc/postfix/main.cf


### PR DESCRIPTION
In the instructions, we are using pcre for header and body check. To use that with postfix, we will need install postfix-pcre. Current docker file installations does not install that and this patch should fix the issue.